### PR TITLE
fix lamp-status-5.6.29 alias in lamp_cli_env_ubuntu_16.04.bash file.

### DIFF
--- a/lamp_cli_env_ubuntu_16.04.bash
+++ b/lamp_cli_env_ubuntu_16.04.bash
@@ -7,7 +7,7 @@ alias lamp-current='echo "[ PATH ]";echo $PATH;echo "";echo "[ LAMP_STACK_VERSIO
 ## lamp ctl script aliases (Add new versions here) ##
 # LAMP 5.6.29
 alias lamp-ctl-5.6.29='sudo /opt/lampstack-5.6.29/ctlscript.sh'
-alias lamp-status-5.6.29='lamp5.6.29-ctl status'
+alias lamp-status-5.6.29='lamp-ctl-5.6.29 status'
 alias lamp-cli-on-5.6.29='start_lamp lampstack-5.6.29'
 alias lamp-cli-off-5.6.29='stop_lamp lampstack-5.6.29'
 


### PR DESCRIPTION
lamp-status-5.6.29 command is not working, so i fixed lamp-status-5.6.29 alias in lamp_cli_env_ubuntu_16.04.bash file.